### PR TITLE
fix: update firebase.json public path for non-monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gym Note Web Frontend
+# Gym Note Web
 
 ## 開発コマンド
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "apps/web/dist",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
## Summary
- firebase.jsonのpublicパスを修正
- `"public": "apps/web/dist"` → `"public": "dist"`に変更

## Details
モノレポ削除後の新しいプロジェクト構造に合わせてFirebase Hostingの設定を更新しました。

## Test Plan
- [x] ビルドが正常に動作することを確認（`npm run build`）
- [x] distディレクトリが正しく生成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)